### PR TITLE
Add enums for user role, incident status and category

### DIFF
--- a/src/main/java/org/example/team6backend/entity/IncidentCategory.java
+++ b/src/main/java/org/example/team6backend/entity/IncidentCategory.java
@@ -1,4 +1,4 @@
-package org.example.team6backend.enums;
+package org.example.team6backend.entity;
 
 public enum IncidentCategory {
     LAUNDRY_ROOM("Laundry Room"),

--- a/src/main/java/org/example/team6backend/entity/IncidentStatus.java
+++ b/src/main/java/org/example/team6backend/entity/IncidentStatus.java
@@ -1,4 +1,4 @@
-package org.example.team6backend.enums;
+package org.example.team6backend.entity;
 
 public enum IncidentStatus {
     OPEN("Open", "Incident has been reported"),

--- a/src/main/java/org/example/team6backend/entity/UserRole.java
+++ b/src/main/java/org/example/team6backend/entity/UserRole.java
@@ -1,4 +1,4 @@
-package org.example.team6backend.enums;
+package org.example.team6backend.entity;
 
 public enum UserRole {
     RESIDENT("Resident", "Can create and view own incidents"),


### PR DESCRIPTION
Close #14 

Jag har hållit enumsen relativt enkla just nu. 
Öppen för ändringar om vi vill justera strukturen eller lägga till flera fält 🙂

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Incident categorization system now enables users to classify incidents into predefined types for better organization and tracking
  * Incident status tracking supports multiple workflow states allowing incidents to progress through their lifecycle
  * User role system provides structured access control with distinct permission levels throughout the application
<!-- end of auto-generated comment: release notes by coderabbit.ai -->