### PR TITLE
Add incident document support with MinIO integration

### DIFF
--- a/src/main/java/org/example/team6backend/config/MinioConfig.java
+++ b/src/main/java/org/example/team6backend/config/MinioConfig.java
@@ -3,12 +3,27 @@ package org.example.team6backend.config;
 import io.minio.MinioClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.annotation.Value;
 
 @Configuration
 public class MinioConfig {
 
+    private final String url;
+    private final String accessKey;
+    private final String secretKey;
+
+    public MinioConfig(
+            @Value("${minio.url}") String url,
+            @Value("{minio.access-key}") String accessKey,
+            @Value("{minio.secret-key}") String secretKey
+    ) {
+        this.url = url;
+        this.accessKey = accessKey;
+        this.secretKey = secretKey;
+    }
+
 	@Bean
 	public MinioClient minioClient() {
-		return MinioClient.builder().endpoint("http://localhost:9000").credentials("minioadmin", "minioadmin").build();
+		return MinioClient.builder().endpoint(url).credentials(accessKey, secretKey).build();
 	}
 }

--- a/src/main/java/org/example/team6backend/config/MinioConfig.java
+++ b/src/main/java/org/example/team6backend/config/MinioConfig.java
@@ -8,19 +8,16 @@ import org.springframework.beans.factory.annotation.Value;
 @Configuration
 public class MinioConfig {
 
-    private final String url;
-    private final String accessKey;
-    private final String secretKey;
+	private final String url;
+	private final String accessKey;
+	private final String secretKey;
 
-    public MinioConfig(
-            @Value("${minio.url}") String url,
-            @Value("{minio.access-key}") String accessKey,
-            @Value("{minio.secret-key}") String secretKey
-    ) {
-        this.url = url;
-        this.accessKey = accessKey;
-        this.secretKey = secretKey;
-    }
+	public MinioConfig(@Value("${minio.url}") String url, @Value("${minio.access-key}") String accessKey,
+			@Value("${minio.secret-key}") String secretKey) {
+		this.url = url;
+		this.accessKey = accessKey;
+		this.secretKey = secretKey;
+	}
 
 	@Bean
 	public MinioClient minioClient() {

--- a/src/main/java/org/example/team6backend/config/MinioConfig.java
+++ b/src/main/java/org/example/team6backend/config/MinioConfig.java
@@ -1,24 +1,14 @@
 package org.example.team6backend.config;
 
 import io.minio.MinioClient;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class MinioConfig {
 
-	@Value("${minio.url}")
-	private String url;
-
-	@Value("${minio.access-key}")
-	private String accessKey;
-
-	@Value("${minio.secret-key}")
-	private String secretKey;
-
 	@Bean
 	public MinioClient minioClient() {
-		return MinioClient.builder().endpoint(url).credentials(accessKey, secretKey).build();
+		return MinioClient.builder().endpoint("http://localhost:9000").credentials("minioadmin", "minioadmin").build();
 	}
 }

--- a/src/main/java/org/example/team6backend/document/controller/DocumentController.java
+++ b/src/main/java/org/example/team6backend/document/controller/DocumentController.java
@@ -2,11 +2,13 @@ package org.example.team6backend.document.controller;
 
 import org.example.team6backend.document.entity.Document;
 import org.example.team6backend.document.service.DocumentService;
+import org.example.team6backend.document.service.MinioService;
 import org.example.team6backend.incident.entity.Incident;
 import org.example.team6backend.incident.service.IncidentService;
 import org.example.team6backend.security.CustomUserDetails;
 import org.example.team6backend.user.entity.AppUser;
 import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -24,10 +26,22 @@ public class DocumentController {
 
 	private final DocumentService documentService;
 	private final IncidentService incidentService;
+	private final MinioService minioService;
 
-	public DocumentController(DocumentService documentService, IncidentService incidentService) {
+	public DocumentController(DocumentService documentService, IncidentService incidentService,
+			MinioService minioService) {
 		this.documentService = documentService;
 		this.incidentService = incidentService;
+		this.minioService = minioService;
+	}
+
+	@GetMapping("/{fileKey}")
+	@ResponseBody
+	public ResponseEntity<Resource> getFile(@PathVariable String fileKey) {
+		InputStream inputStream = minioService.getFile(fileKey);
+
+		return ResponseEntity.ok().contentType(MediaType.APPLICATION_OCTET_STREAM)
+				.body(new InputStreamResource(inputStream));
 	}
 
 	@PostMapping("/upload/{incidentId}")

--- a/src/main/java/org/example/team6backend/document/controller/DocumentController.java
+++ b/src/main/java/org/example/team6backend/document/controller/DocumentController.java
@@ -10,12 +10,14 @@ import org.example.team6backend.user.entity.AppUser;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.io.InputStream;
 import java.util.List;
@@ -37,10 +39,28 @@ public class DocumentController {
 
 	@GetMapping("/{fileKey}")
 	@ResponseBody
-	public ResponseEntity<Resource> getFile(@PathVariable String fileKey) {
+	public ResponseEntity<Resource> getFile(@PathVariable String fileKey,
+    @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        AppUser user = userDetails.getUser();
+
+        Document document = documentService.getByFileKey(fileKey)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+
+        Incident incident = incidentService.getById(document.getIncident().getId(),user);
+        if (incident == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
+
 		InputStream inputStream = minioService.getFile(fileKey);
 
-		return ResponseEntity.ok().contentType(MediaType.APPLICATION_OCTET_STREAM)
+        MediaType mediaType = document.getContentType() != null
+                ? MediaType.parseMediaType(document.getContentType())
+                : MediaType.APPLICATION_OCTET_STREAM;
+
+		return ResponseEntity.ok().contentType(mediaType)
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "inline; filename=\"" + document.getFileName() + "\"")
 				.body(new InputStreamResource(inputStream));
 	}
 

--- a/src/main/java/org/example/team6backend/document/controller/DocumentController.java
+++ b/src/main/java/org/example/team6backend/document/controller/DocumentController.java
@@ -40,27 +40,26 @@ public class DocumentController {
 	@GetMapping("/{fileKey}")
 	@ResponseBody
 	public ResponseEntity<Resource> getFile(@PathVariable String fileKey,
-    @AuthenticationPrincipal CustomUserDetails userDetails) {
+			@AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        AppUser user = userDetails.getUser();
+		AppUser user = userDetails.getUser();
 
-        Document document = documentService.getByFileKey(fileKey)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+		Document document = documentService.getByFileKey(fileKey)
+				.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
 
-        Incident incident = incidentService.getById(document.getIncident().getId(),user);
-        if (incident == null) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        }
+		Incident incident = incidentService.getById(document.getIncident().getId(), user);
+		if (incident == null) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+		}
 
 		InputStream inputStream = minioService.getFile(fileKey);
 
-        MediaType mediaType = document.getContentType() != null
-                ? MediaType.parseMediaType(document.getContentType())
-                : MediaType.APPLICATION_OCTET_STREAM;
+		MediaType mediaType = document.getContentType() != null
+				? MediaType.parseMediaType(document.getContentType())
+				: MediaType.APPLICATION_OCTET_STREAM;
 
 		return ResponseEntity.ok().contentType(mediaType)
-                .header(HttpHeaders.CONTENT_DISPOSITION,
-                        "inline; filename=\"" + document.getFileName() + "\"")
+				.header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + document.getFileName() + "\"")
 				.body(new InputStreamResource(inputStream));
 	}
 

--- a/src/main/java/org/example/team6backend/document/dto/DocumentDTO.java
+++ b/src/main/java/org/example/team6backend/document/dto/DocumentDTO.java
@@ -1,0 +1,11 @@
+package org.example.team6backend.document.dto;
+
+import lombok.Data;
+
+@Data
+public class DocumentDTO {
+	private String fileName;
+	private String fileKey;
+	private String fileUrl;
+	private boolean image;
+}

--- a/src/main/java/org/example/team6backend/document/repository/DocumentRepository.java
+++ b/src/main/java/org/example/team6backend/document/repository/DocumentRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 
 public interface DocumentRepository extends JpaRepository<Document, Long> {
 	List<Document> findByIncident(Incident incident);
-    Optional<Document> findByFileKey(String fileKey);
+	Optional<Document> findByFileKey(String fileKey);
 }

--- a/src/main/java/org/example/team6backend/document/repository/DocumentRepository.java
+++ b/src/main/java/org/example/team6backend/document/repository/DocumentRepository.java
@@ -5,7 +5,9 @@ import org.example.team6backend.incident.entity.Incident;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DocumentRepository extends JpaRepository<Document, Long> {
 	List<Document> findByIncident(Incident incident);
+    Optional<Document> findByFileKey(String fileKey);
 }

--- a/src/main/java/org/example/team6backend/document/service/DocumentService.java
+++ b/src/main/java/org/example/team6backend/document/service/DocumentService.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class DocumentService {
 
-	private final S3Service s3Service;
+	private final MinioService minioService;
 	private final DocumentRepository documentRepository;
 
 	/** Upload file */
@@ -26,7 +26,7 @@ public class DocumentService {
 		boolean uploaded = false;
 
 		try {
-			s3Service.uploadFile(fileKey, file);
+			minioService.uploadFile(fileKey, file);
 			uploaded = true;
 
 			Document document = new Document();
@@ -41,7 +41,7 @@ public class DocumentService {
 		} catch (Exception e) {
 			if (uploaded) {
 				try {
-					s3Service.deleteFile(fileKey);
+					minioService.deleteFile(fileKey);
 				} catch (Exception cleanupEx) {
 					log.warn("Failed to cleanup S3 file: {}", fileKey, cleanupEx);
 				}
@@ -52,12 +52,12 @@ public class DocumentService {
 
 	/** Download file */
 	public InputStream downloadFile(String objectKey) {
-		return s3Service.downloadFile(objectKey);
+		return minioService.downloadFile(objectKey);
 	}
 
 	/** Delete file */
 	public void deleteFile(Document document) {
-		s3Service.deleteFile(document.getFileKey());
+		minioService.deleteFile(document.getFileKey());
 		documentRepository.delete(document);
 	}
 

--- a/src/main/java/org/example/team6backend/document/service/DocumentService.java
+++ b/src/main/java/org/example/team6backend/document/service/DocumentService.java
@@ -6,9 +6,11 @@ import org.example.team6backend.document.entity.Document;
 import org.example.team6backend.document.repository.DocumentRepository;
 import org.example.team6backend.incident.entity.Incident;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Slf4j
@@ -56,13 +58,22 @@ public class DocumentService {
 	}
 
 	/** Delete file */
+    @Transactional
 	public void deleteFile(Document document) {
-		minioService.deleteFile(document.getFileKey());
 		documentRepository.delete(document);
+
+        try {
+            minioService.deleteFile(document.getFileKey());
+        } catch (Exception e) {
+            log.warn("Could not delete file: {}", document.getFileKey(), e);
+        }
 	}
 
 	/** Fetch all files connected to one incident */
 	public List<Document> getDocumentsByIncident(Incident incidentId) {
 		return documentRepository.findByIncident(incidentId);
 	}
+    public Optional<Document> getByFileKey(String fileKey) {
+        return documentRepository.findByFileKey(fileKey);
+    }
 }

--- a/src/main/java/org/example/team6backend/document/service/DocumentService.java
+++ b/src/main/java/org/example/team6backend/document/service/DocumentService.java
@@ -58,22 +58,22 @@ public class DocumentService {
 	}
 
 	/** Delete file */
-    @Transactional
+	@Transactional
 	public void deleteFile(Document document) {
 		documentRepository.delete(document);
 
-        try {
-            minioService.deleteFile(document.getFileKey());
-        } catch (Exception e) {
-            log.warn("Could not delete file: {}", document.getFileKey(), e);
-        }
+		try {
+			minioService.deleteFile(document.getFileKey());
+		} catch (Exception e) {
+			log.warn("Could not delete file: {}", document.getFileKey(), e);
+		}
 	}
 
 	/** Fetch all files connected to one incident */
 	public List<Document> getDocumentsByIncident(Incident incidentId) {
 		return documentRepository.findByIncident(incidentId);
 	}
-    public Optional<Document> getByFileKey(String fileKey) {
-        return documentRepository.findByFileKey(fileKey);
-    }
+	public Optional<Document> getByFileKey(String fileKey) {
+		return documentRepository.findByFileKey(fileKey);
+	}
 }

--- a/src/main/java/org/example/team6backend/document/service/MinioService.java
+++ b/src/main/java/org/example/team6backend/document/service/MinioService.java
@@ -11,7 +11,7 @@ import java.io.InputStream;
 
 @Service
 @RequiredArgsConstructor
-public class S3Service {
+public class MinioService {
 
 	private final MinioClient minioClient;
 
@@ -56,6 +56,14 @@ public class S3Service {
 			minioClient.removeObject(RemoveObjectArgs.builder().bucket(bucketName).object(fileKey).build());
 		} catch (Exception e) {
 			throw new RuntimeException("Failed to delete file " + fileKey, e);
+		}
+	}
+
+	public InputStream getFile(String fileKey) {
+		try {
+			return minioClient.getObject(GetObjectArgs.builder().bucket(bucketName).object(fileKey).build());
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to fetch file " + fileKey, e);
 		}
 	}
 }

--- a/src/main/java/org/example/team6backend/document/service/MinioService.java
+++ b/src/main/java/org/example/team6backend/document/service/MinioService.java
@@ -4,8 +4,10 @@ import io.minio.*;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.io.InputStream;
 
@@ -63,7 +65,7 @@ public class MinioService {
 		try {
 			return minioClient.getObject(GetObjectArgs.builder().bucket(bucketName).object(fileKey).build());
 		} catch (Exception e) {
-			throw new RuntimeException("Failed to fetch file " + fileKey, e);
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "File not found: " + fileKey);
 		}
 	}
 }

--- a/src/main/java/org/example/team6backend/incident/dto/IncidentResponse.java
+++ b/src/main/java/org/example/team6backend/incident/dto/IncidentResponse.java
@@ -1,11 +1,13 @@
 package org.example.team6backend.incident.dto;
 
 import lombok.Data;
+import org.example.team6backend.document.dto.DocumentDTO;
 import org.example.team6backend.incident.entity.Incident;
 import org.example.team6backend.incident.entity.IncidentCategory;
 import org.example.team6backend.incident.entity.IncidentStatus;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 public class IncidentResponse {
@@ -15,11 +17,11 @@ public class IncidentResponse {
 	private String description;
 	private IncidentStatus incidentStatus;
 	private IncidentCategory incidentCategory;
-
 	private String createdBy;
 	private String assignedTo;
-
 	private LocalDateTime createdAt;
+	private boolean hasDocuments;
+	private List<DocumentDTO> documents;
 
 	public static IncidentResponse fromEntity(Incident incident) {
 		IncidentResponse response = new IncidentResponse();
@@ -30,6 +32,14 @@ public class IncidentResponse {
 		response.setIncidentStatus(incident.getIncidentStatus());
 		response.setIncidentCategory(incident.getIncidentCategory());
 		response.setCreatedAt(incident.getCreatedAt());
+		response.setDocuments(incident.getDocuments().stream().map(document -> {
+			DocumentDTO dto = new DocumentDTO();
+			dto.setFileName(document.getFileName());
+			dto.setFileKey(document.getFileKey());
+			return dto;
+		}).toList());
+
+		response.setHasDocuments(incident.getDocuments() != null && !incident.getDocuments().isEmpty());
 
 		response.setCreatedBy(incident.getCreatedBy() != null ? incident.getCreatedBy().getEmail() : null);
 

--- a/src/main/java/org/example/team6backend/incident/repository/IncidentRepository.java
+++ b/src/main/java/org/example/team6backend/incident/repository/IncidentRepository.java
@@ -4,10 +4,25 @@ import org.example.team6backend.user.entity.AppUser;
 import org.example.team6backend.incident.entity.Incident;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface IncidentRepository extends JpaRepository<Incident, Long> {
 
+	@EntityGraph(attributePaths = {"documents", "createdBy", "assignedTo"})
+	Page<Incident> findAll(Pageable pageable);
+
+	@EntityGraph(attributePaths = {"documents", "createdBy", "assignedTo"})
 	Page<Incident> findByCreatedBy(AppUser user, Pageable pageable);
+
+	@EntityGraph(attributePaths = {"documents", "createdBy", "assignedTo"})
 	Page<Incident> findByAssignedTo(AppUser user, Pageable pageable);
+
+	@Query("SELECT i FROM Incident i LEFT JOIN FETCH i.documents WHERE i.id = :id")
+	Optional<Incident> findByIdWithDocuments(@Param("id") Long id);
+
 }

--- a/src/main/java/org/example/team6backend/incident/service/IncidentService.java
+++ b/src/main/java/org/example/team6backend/incident/service/IncidentService.java
@@ -4,7 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.team6backend.activity.service.ActivityLogService;
 import org.example.team6backend.document.entity.Document;
 import org.example.team6backend.document.service.DocumentService;
-import org.example.team6backend.document.service.S3Service;
+import org.example.team6backend.document.service.MinioService;
 import org.example.team6backend.exception.ResourceNotFoundException;
 import org.example.team6backend.incident.dto.IncidentRequest;
 import org.example.team6backend.notification.service.NotificationService;
@@ -36,17 +36,17 @@ public class IncidentService {
 	private final DocumentService documentService;
 	private final AppUserRepository userRepository;
 	private final NotificationService notificationService;
-	private final S3Service s3Service;
+	private final MinioService minioService;
 
 	public IncidentService(IncidentRepository incidentRepository, ActivityLogService activityLogService,
 			DocumentService documentService, AppUserRepository userRepository, NotificationService notificationService,
-			S3Service s3Service) {
+			MinioService minioService) {
 		this.incidentRepository = incidentRepository;
 		this.activityLogService = activityLogService;
 		this.documentService = documentService;
 		this.userRepository = userRepository;
 		this.notificationService = notificationService;
-		this.s3Service = s3Service;
+		this.minioService = minioService;
 	}
 
 	/** Help-method for sorting **/
@@ -90,7 +90,7 @@ public class IncidentService {
 		} catch (Exception e) {
 			for (String key : uploadedKeys) {
 				try {
-					s3Service.deleteFile(key);
+					minioService.deleteFile(key);
 				} catch (Exception cleanupEx) {
 					log.warn("Failed rollback cleanup for fileKey: {}", key, cleanupEx);
 				}
@@ -116,7 +116,7 @@ public class IncidentService {
 	}
 
 	public Incident getById(Long id, AppUser user) {
-		Incident incident = incidentRepository.findById(id)
+		Incident incident = incidentRepository.findByIdWithDocuments(id)
 				.orElseThrow(() -> new ResourceNotFoundException("Not found"));
 
 		boolean isAdmin = user.getRole().name().equals("ADMIN");
@@ -129,11 +129,14 @@ public class IncidentService {
 		return incident;
 	}
 	@Transactional
-	public void deleteIncident(Incident incident) {
+	public void deleteIncident(Long incidentId) {
+
+		Incident incident = incidentRepository.findByIdWithDocuments(incidentId)
+				.orElseThrow(() -> new ResourceNotFoundException("Incident not found!"));
 
 		for (Document document : incident.getDocuments()) {
 			try {
-				s3Service.deleteFile(document.getFileKey());
+				minioService.deleteFile(document.getFileKey());
 			} catch (Exception e) {
 				log.warn("Failed to delete file from S3: " + document.getFileKey(), e);
 			}

--- a/src/main/resources/templates/incidents.html
+++ b/src/main/resources/templates/incidents.html
@@ -135,7 +135,10 @@
 
                 card.innerHTML = `
                     <div class="incident-header">
-                        <div class="incident-title">${escapeHtml(incident.subject)}</div>
+                        <div class="incident-title">
+                            ${escapeHtml(incident.subject)}
+                            ${incident.hasDocuments ? '📎' : ''}
+                        </div>
                         <div class="incident-category">${escapeHtml(incident.incidentCategory)}</div>
                     </div>
 

--- a/src/main/resources/templates/viewincident.html
+++ b/src/main/resources/templates/viewincident.html
@@ -189,6 +189,39 @@
 
             const incident = await response.json();
 
+            let documentHtml = "";
+
+            if (incident.hasDocuments && incident.documents?.length > 0) {
+                documentHtml = `
+                <div style="margin-top:10px; display:flex; gap:12px; flex-wrap:wrap;">
+            ${incident.documents.map(doc => {
+                    const fileUrl = "/documents/" + encodeURIComponent(doc.fileKey);
+                    const isImage = /\.(jpg|jpeg|png|gif|webp)$/i.test(doc.fileName);
+
+                    return isImage
+                        ? `
+                        <a href="${fileUrl}" target="_blank">
+                            <img src="${fileUrl}"
+                                 style="
+                                    width:120px;
+                                    height:120px;
+                                    object-fit:cover;
+                                    border-radius:10px;
+                                    border:1px solid #2a2a2a;
+                                    cursor:pointer;
+                                 " />
+                        </a>
+                      `
+                        : `
+                        <a href="${fileUrl}" target="_blank" class="btn">
+                            📄 ${escapeHtml(doc.fileName)}
+                        </a>
+                      `;
+                }).join("")}
+                </div>
+            `;
+            }
+
             document.getElementById("incident").innerHTML = `
                 <div class="incident-card">
                     <div class="incident-header">
@@ -198,6 +231,7 @@
 
                     <div class="incident-description">
                         ${escapeHtml(incident.description || "No description")}
+                        ${documentHtml}
                     </div>
 
                     <div class="incident-footer">


### PR DESCRIPTION
- Implement file upload for incident attachments
- Store files in MinIO with unique file keys
- Save document metadata in database (fileName, fileKey, contentType)
- Add API endpoint to serve files from MinIO
- Fix frontend rendering of multiple images per incident
- Add image gallery with thumbnails and click-to-open in new tab
- Support mixed file types (images + documents)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented direct file download capability for all documents
  * Documents now display within incident views with image previews and file links
  * Incidents show visual indicators when documents are attached

<!-- end of auto-generated comment: release notes by coderabbit.ai -->