### PR TITLE
fix: change AuditLogRepository to use Pageable for paging query

### DIFF
--- a/src/main/java/org/example/team6backend/auditlog/controller/AuditLogController.java
+++ b/src/main/java/org/example/team6backend/auditlog/controller/AuditLogController.java
@@ -32,8 +32,9 @@ public class AuditLogController {
 	}
 
 	@GetMapping("/user/{userId}")
-	public ResponseEntity<Page<AuditLog>> getLogsByUser(@PathVariable String userId) {
-		Page<AuditLog> logs = auditLogRepository.findByPerformedByIdOrderByCreatedAtDesc(userId);
+	public ResponseEntity<Page<AuditLog>> getLogsByUser(@PathVariable String userId,
+			@PageableDefault(size = 20) Pageable pageable) {
+		Page<AuditLog> logs = auditLogRepository.findByPerformedByIdOrderByCreatedAtDesc(userId, pageable);
 		return ResponseEntity.ok(logs);
 	}
 }

--- a/src/main/java/org/example/team6backend/auditlog/repository/AuditLogRepository.java
+++ b/src/main/java/org/example/team6backend/auditlog/repository/AuditLogRepository.java
@@ -13,5 +13,5 @@ public interface AuditLogRepository extends JpaRepository<AuditLog, Long> {
 			+ "OR LOWER(a.action) LIKE LOWER(CONCAT('%', :s, '%'))")
 	Page<AuditLog> searchLogs(@Param("s") String search, Pageable pageable);
 
-	Page<AuditLog> findByPerformedByIdOrderByCreatedAtDesc(String userId);
+	Page<AuditLog> findByPerformedByIdOrderByCreatedAtDesc(String userId, Pageable pageable);
 }


### PR DESCRIPTION
- Change findByPerformedByIdOrderByCreatedAtDesc from List to Page return type
- Add Pageable parameter to support paging
- Update AuditLogController.getLogsByUser accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination support to audit log retrieval, enabling users to fetch results in manageable pages with a default size of 20 items per page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->